### PR TITLE
delete logs after rotation

### DIFF
--- a/pwnagotchi/log.py
+++ b/pwnagotchi/log.py
@@ -307,3 +307,5 @@ def do_rotate(filename, stats, cfg):
     with open(log_filename, 'rb') as src:
         with gzip.open(archive_filename, 'wb') as dst:
             dst.writelines(src)
+
+    os.remove(log_filename)


### PR DESCRIPTION
This commit deletes the logfile after compression.

The current rotation keeps the logfiles which quickly fills up any
zram compressed log mounts which will cause the pwnagotchi to hang.

Signed-off-by: SK <74106733+skontrolle@users.noreply.github.com>

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- [ ] I have raised an issue to propose this change ([required](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md))


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I've read the [CONTRIBUTION](https://github.com/evilsocket/pwnagotchi/blob/master/CONTRIBUTING.md) guide
- [ ] I have signed-off my commits with `git commit -s`
